### PR TITLE
Update ggAVAX path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ const tokens = [
   { name: 'ankrAVAX', fetchFn: () => defaultFetch({ tokens: ['0xc3344870d52688874b06d844e0c36cc39fc727f6'], url: 'https://api.staking.ankr.com/v1alpha/metrics', path: 'services.{serviceName == "avax"}.apy', scale: 100 }) },
   { name: 'sAVAX',   fetchFn: () => defaultFetch({ tokens: ['0x2b2c81e08f1af8835a78bb2a90ae924ace0ea4be'], url: 'https://api.benqi.fi/liquidstaking/apr', path: 'apr', scale: 10000 }) },
   { name: 'ethX',    fetchFn: () => defaultFetch({ tokens: ['0xa35b1b31ce002fbf2058d22f30f95d405200a15b'], url: 'https://universe.staderlabs.com/eth/apy', path: 'value', scale: 100 }) },
-  { name: 'ggAVAX',  fetchFn: () => defaultFetch({ tokens: ['0xa25eaf2906fa1a3a13edac9b9657108af7b703e3'], url: 'https://api.gogopool.com/metrics', path: 'ggavax_apy', scale: 100 }) },
+  { name: 'ggAVAX',  fetchFn: () => defaultFetch({ tokens: ['0xa25eaf2906fa1a3a13edac9b9657108af7b703e3'], url: 'https://api.gogopool.com/metrics/apy', path: 'total_apy_after_fees', scale: 100 }) },
   { name: 'usdm',    fetchFn: () => defaultFetch({ tokens: ['0x57f5e098cad7a3d1eed53991d4d66c45c9af7812'], url: 'https://apy.prod.mountainprotocol.com', path: 'value', scale: 10000 }) },
   { name: 'overnightDAIPlus', fetchFn: () => defaultFetch({ tokens: ['0x0b8f31480249cc717081928b8af733f45f6915bb'], url: 'https://api.overnight.fi/optimism/dai+/fin-data/avg-apr/week', path: 'value' }) },
   { name: 'overnightUSDPlus', fetchFn: () => defaultFetch({ tokens: ['0xa348700745d249c3b49d2c2acac9a5ae8155f826'], url: 'https://api.overnight.fi/optimism/usd+/fin-data/avg-apr/week', path: 'value' }) },


### PR DESCRIPTION
We are changing how our APY is calculated. This new method better reflects our new strategy of zero fees and boosting with MEV yields, which uses a new endpoint for the improved calculations.