### PR TITLE
weETH-APR-OP-ARB

### DIFF
--- a/src/sources/etherfi.ts
+++ b/src/sources/etherfi.ts
@@ -37,7 +37,7 @@ export const etherfi = async () => {
 
   return {
     '0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee': Math.round(avgApr),
-    '0x346e03f8cce9fe01dcb3d0da3e9d00dc2c0e08f0': Math.round(avgApr),
+    '0x5a7facb970d094b6c7ff1df0ea68D99e6e73cbff': Math.round(avgApr),
     '0x35751007a407ca6feffe80b3cb397736d2cf4dbe': Math.round(avgApr),
   }
 }

--- a/src/sources/etherfi.ts
+++ b/src/sources/etherfi.ts
@@ -37,5 +37,7 @@ export const etherfi = async () => {
 
   return {
     '0xcd5fe23c85820f7b72d0926fc9b05b43e359b7ee': Math.round(avgApr),
+    '0x346e03f8cce9fe01dcb3d0da3e9d00dc2c0e08f0': Math.round(avgApr),
+    '0x35751007a407ca6feffe80b3cb397736d2cf4dbe': Math.round(avgApr),
   }
 }


### PR DESCRIPTION
Please double check my edit of the etherfi file adding new token addresses per network. 

OP Token address 0x346e03f8cce9fe01dcb3d0da3e9d00dc2c0e08f0. 
Arbitrum token address: 0x35751007a407ca6FEFfE80b3cB397736D2cf4dbe

Same APR as mainnet.