### PR TITLE
Stakewise-osGNO-APR

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { etherfi } from './sources/etherfi';
 import { stakewise } from './sources/stakewise';
 import { svEth } from './sources/savvy';
 import { mapleSyrup } from './sources/maple-syrup';
+import { stakewisegno } from './sources/stakewisegno';
 
 export interface Env {
   YIELD_TOKENS: KVNamespace;
@@ -90,6 +91,7 @@ const tokens = [
   { name: 'stakewise', fetchFn: stakewise },
   { name: 'svEth', fetchFn: svEth },
   { name: 'mapleSyrup', fetchFn: mapleSyrup },
+  { name: 'stakewisegno', fetchFn: stakewisegno },
   // { name: 'euler',     fetchFn: euler },
 ]
 

--- a/src/sources/stakewisegno.ts
+++ b/src/sources/stakewisegno.ts
@@ -1,0 +1,44 @@
+const url =
+  'https://gnosis-graph.stakewise.io/subgraphs/name/stakewise/stakewise'
+
+const query = `
+  {
+    osTokens {
+      apy
+    }
+  }
+`
+
+const requestQuery = {
+  query,
+}
+
+interface Response {
+  data: {
+    osTokens: {
+      apy: string[]
+    }[]
+  }
+}
+
+export const stakewisegno = async () => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestQuery),
+  })
+
+  const {
+    data: {
+      osTokens: [{ apy }],
+    },
+  } = (await response.json()) as Response
+
+  const apr = Math.round(Number(apy) * 100)
+
+  return {
+    '0xf490c80aae5f2616d3e3bda2483e30c4cb21d1a0': apr,
+  }
+}


### PR DESCRIPTION
Adding stakewise osGNO apr for Gnosis pool to appear.

Pool: https://balancer.fi/pools/gnosis/v2/0x3220c83e953186f2b9ddfc0b5dd69483354edca20000000000000000000000b0

Asset: https://gnosisscan.io/token/0xf490c80aae5f2616d3e3bda2483e30c4cb21d1a0

Query: https://gnosis-graph.stakewise.io/subgraphs/name/stakewise/stakewise/graphql?query=%7B%0A++osTokens+%7B%0A++++apy%0A++%7D%0A%7D